### PR TITLE
Enforce EOL Normalization

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+* text=auto
+
+*.sh    text eol=lf


### PR DESCRIPTION

Add `.gitattributes` rule to enforce `LF` end-of-line normalization for `*.sh` scripts so that they don't get indexed with CRLF by Windows contributors.

I've checked with Git, and so far the shell scripts are properly indexed with `LF` EOL:

```
$ git ls-files --eol *.sh
i/lf    w/crlf  attr/text eol=lf        scripts/tools/getImageColors.sh
```

But, as you can see (I'm working on Win OS) Windows contributors could easily wreck EOLs in the index without Git settings safeguards like the above. I'm not aware of the proper setting of all the other file extensions in the project, but my guess is that native normalization should be fine in most cases. But it's always safer to explicitly declare every used extension for we can't know how users have configured Git locally.

> __NOTE__ — it might also be worth setting some attributes to target GitHub Linguist for correct stats gathering and syntax highlighting. E.g. vendored and autogenerated files which are not handled by Linguist defaults should be added manually to the `.gitattributes`:
> 
> - https://github.com/github/linguist/blob/master/README.md#overrides
