### PR TITLE
docs: instruction for color name sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,13 +261,16 @@ See [package.json](package.json#L6) for more.
   / [Google Docs](https://docs.google.com/forms/d/e/1FAIpQLSfbS5D6owA4dQupJJ-6qhRzuxkjX9r2AliPMg-VR2V3NpGkQg/viewform)
   / [Github](#contributors-)
 - [Wikipedia list of named colors] (2018-02-23): `wikipedia`
-- [Wada Sanzo's list of named colors]: `sanzoWadaI`
-- [CSS/HTML color names]: `html`
-- [Werner’s Nomenclature of Colours]: `werner`
-- [ntc.js]
-- [xkcd color survey list]
+- [Wada Sanzo's list of named colors] : `sanzoWadaI`
+- [CSS/HTML color names] : `html`
+- [Microsoft Color Names] : `windows`
+- [Werner’s Nomenclature of Colours] : `werner`
+- [The Color Thesaurus by writer Ingrid Sundberg] : `thesaurus`
+- [RAL colors] : `ral`
+- [ntc.js] : `ntc`
+- [xkcd color survey list] : `xkcd`
 - [htmlcsscolor.com]
-- [OSX Crayons]
+- [OSX Crayons] : `osxcrayons`
 - [Crayola crayon]
 - [Japanese Twelve Level Cap and Rank System colors]
 - [Thailand weekday colors]
@@ -438,11 +441,14 @@ so that we can remove them promptly.
 [Military Paint]: http://paintref.com/cgi-bin/colorcodedisplay.cgi?manuf=Military
 [Werner’s Nomenclature of Colours]: https://www.c82.net/werner/
 [ntc.js]: http://chir.ag/projects/ntc/
+[RAL colors]: https://www.ralcolor.com/
 [Olympian god colors]: http://www.hellenicgods.org/colors-associated-with-the-olympian-gods
 [OSX Crayons]: http://www.randomactsofsentience.com/2013/06/os-x-crayon-color-hex-table.html
 [Thailand weekday colors]: https://en.wikipedia.org/wiki/Colors_of_the_day_in_Thailand
 [Wikipedia list of named colors]: https://en.wikipedia.org/wiki/List_of_colors:_A%E2%80%93F
+[Microsoft Color Names]: https://learn.microsoft.com/en-us/dotnet/api/system.windows.media.colors?view=windowsdesktop-7.0
 [Wada Sanzo's list of named colors]: https://sanzo-wada.dmbk.io/
+[The Color Thesaurus by writer Ingrid Sundberg]: https://ingridsnotes.wordpress.com/2014/02/04/the-color-thesaurus/
 [xkcd color survey list]: https://blog.xkcd.com/2010/05/03/color-survey-results/
 
 <!-- Sources: Color -->

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ shifted the colors a bit when there were identical colors with different names.
   hex value below the name.
 - [Color Picker II]: Move your mouse and scroll to choose a color.
 - [Name Search]: full text search on the color list.
+- [Filter color names]: Specify the source for looking up names for a color
 - [Color Distribution] 3D view of all color names in different color spaces.
 - [Twitter Bot]: Posts random colors and lets you submit new ones.
 
@@ -180,6 +181,14 @@ https://api.color.pizza/v1/names/?name={{query}}
 Returns an `array` of color `objects` which match the given query, sorted by color-name:
 `curl` [https://api.color.pizza/v1/names/red](https://api.color.pizza/v1/names/red)
 
+#### Specify a color name source
+
+```url
+https://api.color/pizza/v1/?values={{query}}&&list={{listname}}
+```
+
+See [sources](https://github.com/meodai/color-names#sources-names-) for a list of accepted color lists and their corresponding url-encoded names.
+
 #### Good Color-Names
 
 Not all color-names are created equal; add [`?goodnamesonly=true`](https://api.color.pizza/v1/?values=212121,060606,ff0012,550055,123456&goodnamesonly=true)
@@ -251,10 +260,10 @@ See [package.json](package.json#L6) for more.
 - Thousands of user submissions [Twitter](https://codepen.io/meodai/full/ZXQzLb/)
   / [Google Docs](https://docs.google.com/forms/d/e/1FAIpQLSfbS5D6owA4dQupJJ-6qhRzuxkjX9r2AliPMg-VR2V3NpGkQg/viewform)
   / [Github](#contributors-)
-- [Wikipedia list of named colors] (2018-02-23)
-- [Wada Sanzo's list of named colors]
-- [CSS/HTML color names]
-- [Werner’s Nomenclature of Colours]
+- [Wikipedia list of named colors] (2018-02-23): `wikipedia`
+- [Wada Sanzo's list of named colors]: `sanzoWadaI`
+- [CSS/HTML color names]: `html`
+- [Werner’s Nomenclature of Colours]: `werner`
 - [ntc.js]
 - [xkcd color survey list]
 - [htmlcsscolor.com]


### PR DESCRIPTION
Hi. I've discovered that it's possible to specify the source to lookup names for a color, but it's not documented in the README.

So these are what I added:

- a [Codepen](https://codepen.io/meodai/pen/PoaRgLm) by **meodai** for restricting color names to a particular source
- the query to use for specifying a color name source
- the URL-encoded list names
- reference links for several color lists