### PR TITLE
docs: add demo for previewing lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ shifted the colors a bit when there were identical colors with different names.
 - [Name Search]: full text search on the color list.
 - [Color Distribution] 3D view of all color names in different color spaces.
 - [Twitter Bot]: Posts random colors and lets you submit new ones.
+- [Color List Preview]: Get the names of basic colors from all the supported lists at a glance. Users can enter their own colors.
 
 ## Color Name Submission 💌
 
@@ -379,6 +380,8 @@ so that we can remove them promptly.
 [Name Search]: https://codepen.io/meodai/full/VMpNdQ/
 [Color Distribution]: https://codepen.io/meodai/full/zdgXJj/
 [Twitter Bot]: https://twitter.com/color_parrot
+[Color List Preview]: https://codepen.io/bytrangle/full/jOpOrdv
+
 
 <!-- 3r party libraries & tools -->
 


### PR DESCRIPTION
Hi. I've added a Codepen demo for previewing all the supported color lists in Color Names.

Features:
- Display names from *all* lists for five basic colors
- Users can change colors and the names will be updated on the spot