### PR TITLE
docs(readme): Bump Java/Kotlin library version

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ repositories {
 }
 
 dependencies {
-      implementation("me.aroze:color-names:1.0.2")
+      implementation("me.aroze:color-names:1.0.4")
 }
 ```
 
@@ -205,7 +205,7 @@ dependencies {
 <dependency>
   <groupId>me.aroze</groupId>
   <artifactId>color-names</artifactId>
-  <version>1.0.2</version>
+  <version>1.0.4</version>
 </dependency>
 ```
 


### PR DESCRIPTION
Updates usage for [UwUAroze/Color-Names](https://github.com/UwUAroze/Color-Names/): 1.0.2 -> 1.0.4

The newer version retains existing functionality but notably adds a few more features, fixes a couple issues and allows for safe multithreaded usage. The release notes have some more details. It's worth having this upto date for people looking to use it :p