### PR TITLE
Add new color names to colornames.csv

### DIFF
--- a/src/colornames.csv
+++ b/src/colornames.csv
@@ -28647,11 +28647,11 @@ Think Pink,#e5a5c1,x
 Third Eye Chakra,#243bcd,
 Thirsty Thursday,#726e9b,
 Thistle,#d8bfd8,
-Thistleberry Green,#bfd8bf,
 Thistle Down,#9499bb,
 Thistle Green,#cccaa8,
 Thistle Grey,#c0b6a8,
 Thistle Mauve,#834d7c,
+Thistleberry Green,#bfd8bf,
 Thistleblossom Soft Blue,#8ab3bf,
 Thor’s Thunder,#44ccff,x
 Thorn Crown,#b5a197,

--- a/src/colornames.csv
+++ b/src/colornames.csv
@@ -28380,6 +28380,7 @@ Teakwood,#8d7e6d,x
 Teal,#008080,x
 Teal & Tonic,#71999b,
 Teal Bayou,#57a1a0,
+Teal Beak,#006767,
 Teal Blue,#01889f,
 Teal Dark Blue,#0f4d5c,
 Teal Dark Green,#006d57,
@@ -28646,6 +28647,7 @@ Think Pink,#e5a5c1,x
 Third Eye Chakra,#243bcd,
 Thirsty Thursday,#726e9b,
 Thistle,#d8bfd8,
+Thistleberry Green,#bfd8bf,
 Thistle Down,#9499bb,
 Thistle Green,#cccaa8,
 Thistle Grey,#c0b6a8,

--- a/src/colornames.csv
+++ b/src/colornames.csv
@@ -2413,6 +2413,7 @@ Bering Wave,#3d6d84,
 Berkeley Hills,#7e613f,
 Berkshire Lace,#f0e1cf,
 Berlin Blue,#5588cc,
+Berlin Pink,#ff6989,
 Bermuda,#1b7d8d,x
 Bermuda Blue,#8cb1c2,
 Bermuda Grey,#6b8ba2,

--- a/src/colornames.csv
+++ b/src/colornames.csv
@@ -4442,7 +4442,7 @@ Cabo,#cec0aa,
 Caboose,#a8a4a1,
 Cacao,#6b5848,
 Cacao Nibs,#80442f,x
-Cacazona,#8B3F36,
+Cacazona,#8b3f36,
 Cache Blue,#b5cee0,
 Cache of Camel,#d3c296,
 Cachet Cream,#f3d9ba,

--- a/src/colornames.csv
+++ b/src/colornames.csv
@@ -4442,6 +4442,7 @@ Cabo,#cec0aa,
 Caboose,#a8a4a1,
 Cacao,#6b5848,
 Cacao Nibs,#80442f,x
+Cacazona,#8B3F36,
 Cache Blue,#b5cee0,
 Cache of Camel,#d3c296,
 Cachet Cream,#f3d9ba,


### PR DESCRIPTION
**PR title format:** `feat(colors): Describe your colors`

## Summary

Adds a proposed colour name:

Cacazona #8B3F36

Born out of frustration with a UI accent labelled "Pink" that visually reads much closer to terracotta, clay, or brick red.

## Color source / inspiration

Sampled from a production UI.

## Notes for maintainers

If "Cacazona" is considered inappropriate, feel free to reject it.

I stand by the colour.

## Checklist

- [x] I have read and followed `CONTRIBUTING.md`.
- [x] I only edited `src/colornames.csv` for color name changes (and, if needed,
the relevant allowlist JSON in `tests/`) — no changes to `dist/`, `README.md`,
or `changes.svg`.
- [x] Each line ends with a trailing comma (e.g., `My Color,#ff5733,`).
- [x] New color names:
  - [x] Convey a specific color (not just a vibe or reference).
  - [x] *Follow the "Rules for new color names" (no racist/offensive/obscene/
  brand names, etc.). *caca might be considered rude in some languages, but it is also used as a childish way to say brown.
  - [x] Are not nearly identical to protected primary colors.
  - [x] Use British English spelling where applicable (e.g. `Grey` not `Gray`).
  - [x] Are capitalized in [APA-style title case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case).
- [x] I ran `npm test` locally (or understand CI will run it for me).

## Color source / inspiration

[Medium](https://r2p2.medium.com/openai-changed-pink-1b8173daa849) + [Reddit](https://www.reddit.com/r/ChatGPT/comments/1u87czk/do_you_want_the_old_pink_back/)

## Notes for maintainers

Named during a discussion about whether a colour this close to terracotta can reasonably be called pink. 🏃💨

<img width="761" height="590" alt="Screenshot 2026-06-17 185549" src="https://github.com/user-attachments/assets/83b8c681-671e-4064-84ea-a8f5df6216f9" />
