### PR TITLE
Feat(colors) Greeeeeeen

### DIFF
--- a/src/colornames.csv
+++ b/src/colornames.csv
@@ -12185,6 +12185,7 @@ Greedo Green,#00aa66,
 Greedy Gecko,#aa9922,x
 Greedy Gold,#c4ce3b,
 Greedy Green,#d1ffbd,
+Greeeeeeen,#005300,
 Greek Aubergine,#3d0734,
 Greek Blue,#009fbd,
 Greek Flag Blue,#0d5eaf,
@@ -12196,7 +12197,6 @@ Greek Olive,#a08650,x
 Greek Oregano,#7c754c,x
 Greek Sea,#72a7e1,
 Greek Villa,#f0ece2,
-Greeeeeeen,#005300,
 Green,#00ff00,x
 Green 383,#3e3d29,
 Green Acres,#53a144,

--- a/src/colornames.csv
+++ b/src/colornames.csv
@@ -12197,6 +12197,7 @@ Greek Oregano,#7c754c,x
 Greek Sea,#72a7e1,
 Greek Villa,#f0ece2,
 Green,#00ff00,x
+Greeeeeeen,#005300,
 Green 383,#3e3d29,
 Green Acres,#53a144,
 Green Adirondack,#688878,

--- a/src/colornames.csv
+++ b/src/colornames.csv
@@ -12196,8 +12196,8 @@ Greek Olive,#a08650,x
 Greek Oregano,#7c754c,x
 Greek Sea,#72a7e1,
 Greek Villa,#f0ece2,
-Green,#00ff00,x
 Greeeeeeen,#005300,
+Green,#00ff00,x
 Green 383,#3e3d29,
 Green Acres,#53a144,
 Green Adirondack,#688878,


### PR DESCRIPTION
I know it’s been awhile BUT listen this one out 

This is called “Greeeeeeen” it is the reference to the well known Tetris milestone there are other known ones even get mentioned on Wikipedia “dusk” and “charcoal” but “Greeeeeeen” here is influencial because in the tetris community it was a big milestone in one of the largest point record of 16 million points for being having to suffer 860 lines of “Greeeeeeen”

Now I understand the name can be lackluster and creativity and may to niche for the list but I do recommend this because it is a notable moment in history because it was on the news for a kid beating tetris so tetris has it’s importance 

If this name does fail and there are a better suggestable idea I’ll be happy to accept that

Oh and the hex is taken eyedropped exactly from the game’s glicthed color palette when it gets to level “Greeeeeeen” itself

<img width="970" height="766" alt="IMG_2442" src="https://github.com/user-attachments/assets/c0c8feec-3aba-4716-80ff-5b91d28c9fcc" />
