### PR TITLE
docs: add Swift usage guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ Other language implementations maintained by the community:
 - Java/Kotlin: [docs/usage-java-kotlin.md](docs/usage-java-kotlin.md)
 - C#: [docs/usage-csharp.md](docs/usage-csharp.md)
 - Rust: [docs/usage-rust.md](docs/usage-rust.md)
+- Swift: [docs/usage-swift.md](docs/usage-swift.md)
 
 ## Explore 🌍
 
@@ -238,11 +239,12 @@ npm install && npm run build
 
 See [package.json](package.json#L6) for details.
 
-### Java/Kotlin, C#, Rust
+### Java/Kotlin, C#, Rust, Swift
 
 - [docs/usage-java-kotlin.md](docs/usage-java-kotlin.md)
 - [docs/usage-csharp.md](docs/usage-csharp.md)
 - [docs/usage-rust.md](docs/usage-rust.md)
+- [docs/usage-swift.md](docs/usage-swift.md)
 
 ## Sources 🗒
 

--- a/docs/usage-swift.md
+++ b/docs/usage-swift.md
@@ -1,0 +1,58 @@
+# Swift Usage
+
+Swift support is provided by
+[yonilevy/swift-color-names](https://github.com/yonilevy/swift-color-names).
+It bundles this dataset and adds closest-named-color search in the perceptual
+[OKLab](https://bottosson.github.io/posts/oklab/) space.
+
+## Installation
+
+Add the package with Swift Package Manager:
+
+```swift
+.package(url: "https://github.com/yonilevy/swift-color-names.git", from: "1.0.0")
+```
+
+```swift
+.target(name: "MyApp", dependencies: [
+  .product(name: "ColorNames", package: "swift-color-names"),
+])
+```
+
+## Creating the instance
+
+Pick which slice of the dataset to load — `.full`, `.bestOf`, or `.short`
+(the `.bestOf` names limited to 12 characters or fewer):
+
+```swift
+import ColorNames
+
+let colorNames = ColorNames(.short)
+```
+
+## Getting a fitting color name
+
+```swift
+// Closest name to an sRGB value…
+let fromRgb = colorNames.find(rgb: RGB(red255: 224, green255: 224, blue255: 255))
+fromRgb?.name  // "Velvet Scarf"
+
+// …or straight from a hex string:
+let fromHex = colorNames.find(hex: "#facfea")
+fromHex?.name  // "Puff of Pink"
+
+// The result carries name, sRGB, precomputed OKLab, and hex — note the hex is
+// the matched color's, not your input:
+fromHex?.hex   // "#FFCBEE"
+
+// Exact lookups (no distance search):
+colorNames.color(named: "Red")?.hex    // "#FF0000"
+colorNames.color(hex: "#000000")?.name  // "Black"
+```
+
+Search runs by brute force over the chosen list in OKLab space, so numeric
+closeness matches perceived closeness. `find(…)` returns `nil` only when the
+database is empty (or the hex string is invalid).
+
+See the upstream project for more details and updates:
+[yonilevy/swift-color-names](https://github.com/yonilevy/swift-color-names)


### PR DESCRIPTION
## Summary

Document the Swift implementation (yonilevy/swift-color-names), which bundles this dataset and adds OKLab closest-color search. Add docs/usage-swift.md and link it from the README language lists.

## Checklist

- [x] I have read and followed `CONTRIBUTING.md`.
- [ ] I only edited `src/colornames.csv` for color name changes (and, if needed,
the relevant allowlist JSON in `tests/`) — no changes to `dist/`, `README.md`,
or `changes.svg`.
- [ ] Each line ends with a trailing comma (e.g., `My Color,#ff5733,`).
- [ ] New color names:
  - [ ] Convey a specific color (not just a vibe or reference).
  - [ ] Follow the "Rules for new color names" (no racist/offensive/obscene/
  brand names, etc.).
  - [ ] Are not nearly identical to protected primary colors.
  - [ ] Use British English spelling where applicable (e.g. `Grey` not `Gray`).
  - [ ] Are capitalized in [APA-style title case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case).
- [ ] I ran `npm test` locally (or understand CI will run it for me).

## Color source / inspiration

NA
